### PR TITLE
Links on First Flight assignment made more legible

### DIFF
--- a/templates/hw/firstflight.mak
+++ b/templates/hw/firstflight.mak
@@ -130,11 +130,11 @@ and/or all of the above.
     <ol>
         <li>
         Create a blog if you don’t already have one. There are lots of free
-        services available. You might try <code><a target="_blank" href="http://wordpress.com">http://wordpress.com</a></code> or
+        services available. You might try <code><a target="_blank" href="http://wordpress.com" style="color:#303f9f">http://wordpress.com</a></code> or
         <code><a target="_blank"
-                href="http://blogspot.com">http://blogspot.com</a></code>, or
+                href="http://blogspot.com" style="color:#303f9f">http://blogspot.com</a></code>, or
         even <code><a target="_blank"
-        href="http://foss.rit.edu">http://foss.rit.edu</a></code>.
+        href="http://foss.rit.edu" style="color:#303f9f">http://foss.rit.edu</a></code>.
         </li>
         <li>Write an introductory post, detailing the process you went through
         to complete the <em>FirstFlight</em> assignment.</li>


### PR DESCRIPTION
So, looking at the assignment that's currently there, you've got white links on a white bubble background.  Have a slight patch for that (added style attributes to the three links that have the issue).

Not too pretty, but hopefully we aren't looking at this assignment for too much longer.