### PR TITLE
Initialize 2016 directory for spring, add jflory7.yaml

### DIFF
--- a/people/2016/spring/jflory7.yaml
+++ b/people/2016/spring/jflory7.yaml
@@ -1,0 +1,10 @@
+name: Justin W. Flory
+blog: https://blog.justinwflory.com
+feed: https://blog.justinwflory.com/tag/hfoss/feed/
+email: jflory7@gmail.com
+major: Networking & Systems Administration 2019
+irc: jflory7
+forges:
+  GitHub: https://github.com/jflory7
+  BitBucket: https://bitbucket.org/jflory7
+bio: FOSS forever. Fedora contributor, RIT Class of 2019, RITlug member.


### PR DESCRIPTION
This commit initializes and adds directories for year 2016 and spring, and adds my own YAML profile to the list. Followed the examples provided by [`dzho.yaml`](https://github.com/ritjoe/hfoss/blob/master/people/2015/fall/dzho.yaml) and my file in [FOSSProfiles](https://github.com/FOSSRIT/FOSSProfiles/blob/master/profiles/student/jflory7.yaml).