### PR TITLE
Fix forge YAML lists for ofCourse -- this was an older format

### DIFF
--- a/people/2016/spring/LunaLovecraft.yaml
+++ b/people/2016/spring/LunaLovecraft.yaml
@@ -7,5 +7,5 @@ major: Game Design and Development
 irc: LunaLovecraft
 rit_dce: am9813
 forges:
-  GitHub: https://github.com/LunaLovecraft
+  - https://github.com/LunaLovecraft
 bio: Obsessed with procedural generation.

--- a/people/2016/spring/nolski.yaml
+++ b/people/2016/spring/nolski.yaml
@@ -5,6 +5,6 @@ major: New Media Interactive Dev 2016
 irc: nolski
 rit_dce: None
 forges:
-  GitHub: https://github.com/nolski
+  - https://github.com/nolski
 bio: Truth seeking cyber missile. JS/Python hacker. Opinionated freedom fighter
     and life long learner.


### PR DESCRIPTION
This pull request adjusts the remaining student YAML files that use an incorrect format for forges. This format appears to be an older format used for ofCourse.