### PR TITLE
Correct URL for firstflight, add litreview1

### DIFF
--- a/people/2016/spring/jflory7.yaml
+++ b/people/2016/spring/jflory7.yaml
@@ -12,4 +12,5 @@ forges:
   - https://bitbucket.org/jflory7
 bio: FOSS forever. At RIT, I participate in RITlug, NextHop, and FOSS@MAGIC. Elsewhere, I am a contributor to the Fedora Project, staff member of the SpigotMC project, and a few smaller things.
 hw:
-  firstflight: https://blog.justinwflory.com/2016/01/first-flight-my-foray-into-hfoss/
+  firstflight: https://blog.justinwflory.com/2016/01/hfoss-first-flight/
+  litreview1: https://blog.justinwflory.com/2016/02/reviewing-what-is-open-source-steve-weber/


### PR DESCRIPTION
Corrects the URL for my firstflight post and adds the litreview1 post. At the time of commit, the blog post is not live, but it is scheduled for 8:00 UTC (i.e. 3am US EST) for ideal global exposure in regards to time zones.