### PR TITLE
Correct Smoke Test URL for older OLPC firmware (thanks @spg1502)

### DIFF
--- a/templates/syllabus.mak
+++ b/templates/syllabus.mak
@@ -479,7 +479,7 @@
 
             <td>
                 <p class="topic ">
-                <a target="_blank" href="http://wiki.laptop.org/go/Smoke_test/10.1.x/1_hour_smoke_test">Smoke Test</a>
+                <a target="_blank" href="http://wiki.laptop.org/go/Smoke_test/11.2.x/1_hour_smoke_test">Smoke Test</a>
                 </p>
             </td>
         </tr>


### PR DESCRIPTION
It came up in class that one of the URLs for the smoke test was outdated and pointed to an older version of the OLPC firmware (for 10.x). This corrects that URL to mirror the other URLs for the smoke test in the syllabus, for 11.x. Thanks to @spg1502 for noticing this flaw on the syllabus.