### PR TITLE
Add Community Architecture project links to YAML file

### DIFF
--- a/people/2016/spring/jflory7.yaml
+++ b/people/2016/spring/jflory7.yaml
@@ -21,3 +21,4 @@ hw:
   teamprop1: https://blog.justinwflory.com/2016/03/hfoss-commarch-project-proposal/
   quiz1: https://blog.justinwflory.com/2016/03/hfoss-quiz-1/
   commarchreport: https://blog.justinwflory.com/2016/03/community-architecture-project-report/
+  commarchpreso: https://s.j-f.co/1S0avh5

--- a/people/2016/spring/jflory7.yaml
+++ b/people/2016/spring/jflory7.yaml
@@ -20,3 +20,4 @@ hw:
   smoketest: https://blog.justinwflory.com/2016/02/smoke-test-xo-laptop/
   teamprop1: https://blog.justinwflory.com/2016/03/hfoss-commarch-project-proposal/
   quiz1: https://blog.justinwflory.com/2016/03/hfoss-quiz-1/
+  commarchreport: https://blog.justinwflory.com/2016/03/community-architecture-project-report/


### PR DESCRIPTION
This commit adds my blog post for the Community Architecture project report and the URL to the Google Drive presentation for our project to my YAML file.