### PR TITLE
Added finalrepo to personal yaml file

### DIFF
--- a/people/2016/spring/spg1502.yaml
+++ b/people/2016/spring/spg1502.yaml
@@ -23,3 +23,4 @@ hw:
   commarchpreso: https://s.j-f.co/1S0avh5
   teamprop2: https://spg1502igme582.wordpress.com/2016/04/03/final-project-team-proposal/
   quiz2: https://spg1502igme582.wordpress.com/2016/04/06/quiz-2/
+  finalrepo: https://github.com/FOSSRIT/PyCut


### PR DESCRIPTION
I added a link to my team's final repo on github. This repo is hosted
within the FOSSRIT github group, all the code has been ported over from
out private jflory7/PyCut repo