### PR TITLE
Color Legend For Syllabus Schedule v.1 (moved branch)

### DIFF
--- a/people/2017/spring/Brian-Sandon.yaml
+++ b/people/2017/spring/Brian-Sandon.yaml
@@ -20,3 +20,4 @@ hw:
   blog01: https://briansandonprogramming.wordpress.com/2017/02/06/hfoss-blog-update-1/
   blog02: https://briansandonprogramming.wordpress.com/2017/02/10/hfoss-blog-update-2/
   blog03: https://briansandonprogramming.wordpress.com/2017/02/20/hfoss-blog-update-3/
+  blog04: https://briansandonprogramming.wordpress.com/2017/02/25/hfoss-blog-update-4/

--- a/people/2017/spring/Brian-Sandon.yaml
+++ b/people/2017/spring/Brian-Sandon.yaml
@@ -16,7 +16,6 @@ hw:
   litreview1: https://briansandonprogramming.wordpress.com/2017/02/05/hfoss-literature-review-1-what-is-open-source/
   bugfix: https://briansandonprogramming.wordpress.com/2017/02/24/hfoss-bugfix/
   meetup1: https://briansandonprogramming.wordpress.com/2017/02/12/meetup-1-brickhack/
-  meetup2: https://briansandonprogramming.wordpress.com/2017/02/25/meetup-2-ritlugfebuary-24th/
   blog01: https://briansandonprogramming.wordpress.com/2017/02/06/hfoss-blog-update-1/
   blog02: https://briansandonprogramming.wordpress.com/2017/02/10/hfoss-blog-update-2/
   blog03: https://briansandonprogramming.wordpress.com/2017/02/20/hfoss-blog-update-3/

--- a/people/2017/spring/Brian-Sandon.yaml
+++ b/people/2017/spring/Brian-Sandon.yaml
@@ -20,4 +20,3 @@ hw:
   blog01: https://briansandonprogramming.wordpress.com/2017/02/06/hfoss-blog-update-1/
   blog02: https://briansandonprogramming.wordpress.com/2017/02/10/hfoss-blog-update-2/
   blog03: https://briansandonprogramming.wordpress.com/2017/02/20/hfoss-blog-update-3/
-  blog04: https://briansandonprogramming.wordpress.com/2017/02/25/hfoss-blog-update-4/

--- a/people/2017/spring/Brian-Sandon.yaml
+++ b/people/2017/spring/Brian-Sandon.yaml
@@ -16,6 +16,7 @@ hw:
   litreview1: https://briansandonprogramming.wordpress.com/2017/02/05/hfoss-literature-review-1-what-is-open-source/
   bugfix: https://briansandonprogramming.wordpress.com/2017/02/24/hfoss-bugfix/
   meetup1: https://briansandonprogramming.wordpress.com/2017/02/12/meetup-1-brickhack/
+  meetup2: https://briansandonprogramming.wordpress.com/2017/02/25/meetup-2-ritlugfebuary-24th/
   blog01: https://briansandonprogramming.wordpress.com/2017/02/06/hfoss-blog-update-1/
   blog02: https://briansandonprogramming.wordpress.com/2017/02/10/hfoss-blog-update-2/
   blog03: https://briansandonprogramming.wordpress.com/2017/02/20/hfoss-blog-update-3/

--- a/people/2017/spring/Brian-Sandon.yaml
+++ b/people/2017/spring/Brian-Sandon.yaml
@@ -14,6 +14,7 @@ hw:
   firstflight: https://briansandonprogramming.wordpress.com/2017/01/28/hfoss-firstflight/
   smoketest: https://briansandonprogramming.wordpress.com/2017/02/17/hfoss-xo-smoketest/
   litreview1: https://briansandonprogramming.wordpress.com/2017/02/05/hfoss-literature-review-1-what-is-open-source/
+  bugfix: https://briansandonprogramming.wordpress.com/2017/02/24/hfoss-bugfix/
   meetup1: https://briansandonprogramming.wordpress.com/2017/02/12/meetup-1-brickhack/
   blog01: https://briansandonprogramming.wordpress.com/2017/02/06/hfoss-blog-update-1/
   blog02: https://briansandonprogramming.wordpress.com/2017/02/10/hfoss-blog-update-2/

--- a/people/2017/spring/Brian-Sandon.yaml
+++ b/people/2017/spring/Brian-Sandon.yaml
@@ -14,7 +14,6 @@ hw:
   firstflight: https://briansandonprogramming.wordpress.com/2017/01/28/hfoss-firstflight/
   smoketest: https://briansandonprogramming.wordpress.com/2017/02/17/hfoss-xo-smoketest/
   litreview1: https://briansandonprogramming.wordpress.com/2017/02/05/hfoss-literature-review-1-what-is-open-source/
-  bugfix: https://briansandonprogramming.wordpress.com/2017/02/24/hfoss-bugfix/
   meetup1: https://briansandonprogramming.wordpress.com/2017/02/12/meetup-1-brickhack/
   blog01: https://briansandonprogramming.wordpress.com/2017/02/06/hfoss-blog-update-1/
   blog02: https://briansandonprogramming.wordpress.com/2017/02/10/hfoss-blog-update-2/

--- a/templates/syllabus.mak
+++ b/templates/syllabus.mak
@@ -1422,18 +1422,19 @@
 </div>
 
 <div class="section">
-    <!--Color Legend for Schedule-->
-    <!--<a class="headerlink" name="Legend"></a>-->
-    <h3>Legend</h3>
-    <table>
-        <!--<tr><td><p class="topic"></p></td></tr>-->
-        <tr><td><p class="special">special topic/assignment</p></td></tr>
-        <tr><td><p class="hackathon">hackathon</p></td></tr>
-        <tr><td><p class="guest">guest</p></td></tr>
-        <tr><td><p class="cancelled">CANCELLED</p></td></tr>
-    </table>
-    
-</div>
+		<!--Color Legend for Schedule-->
+		<!--<a class="headerlink" name="Legend"></a>-->
+		<table class="table-bordered">
+			<tr><th>Legend</th></tr>
+			<!--<tr><td><p class="topic"></p></td></tr>-->
+			<tr><td><p class="special">special topic/assignment</p></td></tr>
+			<tr><td><p class="hackathon">hackathon</p></td></tr>
+			<tr><td><p class="guest">guest</p></td></tr>
+			<tr><td><p class="vaycay">vacation</p></td></tr>
+			<tr><td><p class="cancelled">CANCELLED</p></td></tr>
+		</table>
+		
+	</div>
 
 <div class="section">
     <a class="headerlink" name="attendance"></a>

--- a/templates/syllabus.mak
+++ b/templates/syllabus.mak
@@ -1422,6 +1422,20 @@
 </div>
 
 <div class="section">
+    <!--Color Legend for Schedule-->
+    <!--<a class="headerlink" name="Legend"></a>-->
+    <h3>Legend</h3>
+    <table>
+        <!--<tr><td><p class="topic"></p></td></tr>-->
+        <tr><td><p class="special">special topic/assignment</p></td></tr>
+        <tr><td><p class="hackathon">hackathon</p></td></tr>
+        <tr><td><p class="guest">guest</p></td></tr>
+        <tr><td><p class="cancelled">CANCELLED</p></td></tr>
+    </table>
+    
+</div>
+
+<div class="section">
     <a class="headerlink" name="attendance"></a>
     <h2>Attendance</h2>
     <p>Attendance is <em><strong>required</strong></em> for this course. Students are allotted <span class="label label-danger">2</span> <strong><u>excused</u></strong> absences per semester.</p>


### PR DESCRIPTION
Summary:
*Adds a legend to the syllabus page after the schedule, detailing the significance of the colors used in the schedule.
*I was able to check that the table displayed in an appropriate manner. However, I don't know if these changes will break any of the scripts used by the site, as I couldn't get ofcourse working.
*Moved from bxs9775\master
