### PR TITLE
Fixes reverts - Brian Sandon

### DIFF
--- a/people/2017/spring/Brian-Sandon.yaml
+++ b/people/2017/spring/Brian-Sandon.yaml
@@ -20,3 +20,4 @@ hw:
   blog01: https://briansandonprogramming.wordpress.com/2017/02/06/hfoss-blog-update-1/
   blog02: https://briansandonprogramming.wordpress.com/2017/02/10/hfoss-blog-update-2/
   blog03: https://briansandonprogramming.wordpress.com/2017/02/20/hfoss-blog-update-3/
+  blog04: https://briansandonprogramming.wordpress.com/2017/02/25/hfoss-blog-update-4/

--- a/people/2017/spring/Brian-Sandon.yaml
+++ b/people/2017/spring/Brian-Sandon.yaml
@@ -16,6 +16,7 @@ hw:
   litreview1: https://briansandonprogramming.wordpress.com/2017/02/05/hfoss-literature-review-1-what-is-open-source/
   bugfix: https://briansandonprogramming.wordpress.com/2017/02/24/hfoss-bugfix/
   meetup1: https://briansandonprogramming.wordpress.com/2017/02/12/meetup-1-brickhack/
+  meetup2: https://briansandonprogramming.wordpress.com/2017/02/25/meetup-2-ritlugfebuary-24th/
   blog01: https://briansandonprogramming.wordpress.com/2017/02/06/hfoss-blog-update-1/
   blog02: https://briansandonprogramming.wordpress.com/2017/02/10/hfoss-blog-update-2/
   blog03: https://briansandonprogramming.wordpress.com/2017/02/20/hfoss-blog-update-3/

--- a/people/2017/spring/Brian-Sandon.yaml
+++ b/people/2017/spring/Brian-Sandon.yaml
@@ -14,6 +14,7 @@ hw:
   firstflight: https://briansandonprogramming.wordpress.com/2017/01/28/hfoss-firstflight/
   smoketest: https://briansandonprogramming.wordpress.com/2017/02/17/hfoss-xo-smoketest/
   litreview1: https://briansandonprogramming.wordpress.com/2017/02/05/hfoss-literature-review-1-what-is-open-source/
+  bugfix: https://briansandonprogramming.wordpress.com/2017/02/24/hfoss-bugfix/
   meetup1: https://briansandonprogramming.wordpress.com/2017/02/12/meetup-1-brickhack/
   blog01: https://briansandonprogramming.wordpress.com/2017/02/06/hfoss-blog-update-1/
   blog02: https://briansandonprogramming.wordpress.com/2017/02/10/hfoss-blog-update-2/

--- a/people/2017/spring/Brian-Sandon.yaml
+++ b/people/2017/spring/Brian-Sandon.yaml
@@ -15,9 +15,11 @@ hw:
   smoketest: https://briansandonprogramming.wordpress.com/2017/02/17/hfoss-xo-smoketest/
   litreview1: https://briansandonprogramming.wordpress.com/2017/02/05/hfoss-literature-review-1-what-is-open-source/
   bugfix: https://briansandonprogramming.wordpress.com/2017/02/24/hfoss-bugfix/
+  teamprop1: https://briansandonprogramming.wordpress.com/2017/03/04/commarch-team-proposal/
   meetup1: https://briansandonprogramming.wordpress.com/2017/02/12/meetup-1-brickhack/
   meetup2: https://briansandonprogramming.wordpress.com/2017/02/25/meetup-2-ritlugfebuary-24th/
   blog01: https://briansandonprogramming.wordpress.com/2017/02/06/hfoss-blog-update-1/
   blog02: https://briansandonprogramming.wordpress.com/2017/02/10/hfoss-blog-update-2/
   blog03: https://briansandonprogramming.wordpress.com/2017/02/20/hfoss-blog-update-3/
   blog04: https://briansandonprogramming.wordpress.com/2017/02/25/hfoss-blog-update-4/
+  blog05: https://briansandonprogramming.wordpress.com/2017/03/03/hfoss-blog-5/

--- a/templates/syllabus.mak
+++ b/templates/syllabus.mak
@@ -1427,6 +1427,20 @@
 </div>
 
 <div class="section">
+    <!--Color Legend for Schedule-->
+    <!--<a class="headerlink" name="Legend"></a>-->
+    <h3>Legend</h3>
+    <table>
+        <!--<tr><td><p class="topic"></p></td></tr>-->
+        <tr><td><p class="special">special topic/assignment</p></td></tr>
+        <tr><td><p class="hackathon">hackathon</p></td></tr>
+        <tr><td><p class="guest">guest</p></td></tr>
+        <tr><td><p class="cancelled">CANCELLED</p></td></tr>
+    </table>
+    
+</div>
+
+<div class="section">
     <a class="headerlink" name="attendance"></a>
     <h2>Attendance</h2>
     <p>Attendance is <em><strong>required</strong></em> for this course. Students are allotted <span class="label label-danger">2</span> <strong><u>excused</u></strong> absences per semester.</p>

--- a/templates/syllabus.mak
+++ b/templates/syllabus.mak
@@ -1427,18 +1427,19 @@
 </div>
 
 <div class="section">
-    <!--Color Legend for Schedule-->
-    <!--<a class="headerlink" name="Legend"></a>-->
-    <h3>Legend</h3>
-    <table>
-        <!--<tr><td><p class="topic"></p></td></tr>-->
-        <tr><td><p class="special">special topic/assignment</p></td></tr>
-        <tr><td><p class="hackathon">hackathon</p></td></tr>
-        <tr><td><p class="guest">guest</p></td></tr>
-        <tr><td><p class="cancelled">CANCELLED</p></td></tr>
-    </table>
-    
-</div>
+		<!--Color Legend for Schedule-->
+		<!--<a class="headerlink" name="Legend"></a>-->
+		<table class="table-bordered">
+			<tr><th>Legend</th></tr>
+			<!--<tr><td><p class="topic"></p></td></tr>-->
+			<tr><td><p class="special">special topic/assignment</p></td></tr>
+			<tr><td><p class="hackathon">hackathon</p></td></tr>
+			<tr><td><p class="guest">guest</p></td></tr>
+			<tr><td><p class="vaycay">vacation</p></td></tr>
+			<tr><td><p class="cancelled">CANCELLED</p></td></tr>
+		</table>
+		
+	</div>
 
 <div class="section">
     <a class="headerlink" name="attendance"></a>


### PR DESCRIPTION
* Removes the reverts that cover up the color legend, 2nd meetup, and 4th blog post commits.

Edit (3/14/17):
*Added links for Blog Update 5 and Team Proposal. These changes were added after @jflory7 approved the pull request. 