### PR TITLE
Add firstflight as blog1

### DIFF
--- a/ofcourse-content/people/2018/spring/ctmartin.yaml
+++ b/ofcourse-content/people/2018/spring/ctmartin.yaml
@@ -11,3 +11,4 @@ forges:
 bio: Member of RITlug and FOSS@MAGIC
 hw:
   firstflight: https://blog.ctmartin.me/2018/01/hfoss-firstflight/
+  blog1: https://blog.ctmartin.me/2018/01/hfoss-firstflight/


### PR DESCRIPTION
Since https://github.com/ritjoe/hfoss/wiki/grading-policies#blogs says "Can make weekly blog post and assignment posts at one time, but must submit the link for each" - adding firstflight as blog1